### PR TITLE
update beacon-chain image

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ You can check it by looking at the validator logs: http://my.dappnode/#/Packages
 ![](https://i.imgur.com/Sfq88es.png)
 
 
+## Updating beacon chain image
+To update the beacon chain image, update the sha256 hash of the image.
+
+The hash is stored as a build arg in the [docker-compose file](./docker-compose.yml)
+
+
 ## Note
 
 This is early stage software and it's just a PoC

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,2 @@
-FROM gcr.io/prysmaticlabs/prysm/beacon-chain@sha256:113a07ab26a0e269cd0aee872f24464f163db353d658e32cc990e15fe205c856 as binary
-
-FROM alpine
-
-# Install dependencies
-RUN apk --update add bash ca-certificates libc6-compat && \
-    rm  -rf /tmp/* /var/cache/apk/*
-
-COPY --from=binary /app/beacon-chain/image.binary /usr/local/bin/beacon-chain
-
-ENTRYPOINT beacon-chain --datadir=/data --init-sync-no-verify $EXTRA_OPTS
+ARG SHA256
+FROM gcr.io/prysmaticlabs/prysm/beacon-chain@$SHA256

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -8,7 +8,8 @@
   "author": "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)",
   "contributors": [
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)",
-    "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)"
+    "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
+    "Nate Gentile <nate.gentile@whiteblock.io> (https://github.com/Leibniz137)"
   ],
   "license": "GPL-3.0",
   "repository": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,17 @@ version: '3.4'
 services:
   prysm-beacon-chain.public.dappnode.eth:
     image: 'prysm-beacon-chain.public.dappnode.eth:0.1.3'
-    build: ./build
+    build:
+      context: ./build
+      # put SHA256 on it's own line so that it can be easily replaced with sed
+      args:
+        - >-
+          SHA256=sha256:12dd8ace1d9f754184de2574eab96a8f447ca5c89e0b0c9f5bf25fa558acd80a
+    command: '--datadir=/data'
     volumes:
       - 'data:/data'
     ports:
       - '4000:4000'
     restart: always
-    environment:
-      - EXTRA_OPTS
 volumes:
   data: {}


### PR DESCRIPTION
I changed slightly how the image sha256 hash is specified, to update the image you update the build-arg in the docker-compose file

This diff also explicitly specifies the directory for the beacon chain data.